### PR TITLE
Fix duplicate header and footer

### DIFF
--- a/kjt-portfolio/src/app/[slug]/page.tsx
+++ b/kjt-portfolio/src/app/[slug]/page.tsx
@@ -1,6 +1,5 @@
 import { getPageData, getAllPages } from '@/lib/data';
 import SectionRenderer from '@/components/SectionRenderer';
-import Header from '@/components/Header';
 import { notFound } from 'next/navigation';
 import { Metadata } from 'next';
 
@@ -12,9 +11,11 @@ interface PageProps {
 
 export async function generateStaticParams() {
   const pages = getAllPages();
-  return pages.map((page) => ({
-    slug: page.slug,
-  }));
+  return pages
+    .filter((page) => page.slug !== 'homepage')
+    .map((page) => ({
+      slug: page.slug,
+    }));
 }
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
@@ -42,8 +43,7 @@ export default function DynamicPage({ params }: PageProps) {
 
   return (
     <main className="min-h-screen">
-      <Header />
       <SectionRenderer sections={pageData.sections} />
     </main>
   );
-} 
+}

--- a/kjt-portfolio/src/app/about/page.tsx
+++ b/kjt-portfolio/src/app/about/page.tsx
@@ -1,16 +1,12 @@
 import { getPageData } from '@/lib/data';
 import SectionRenderer from '@/components/SectionRenderer';
-import Header from '@/components/Header';
-import Footer from '@/components/Footer';
 
 export default function AboutPage() {
   const pageData = getPageData('about');
   if (!pageData) return null;
   return (
     <main className="min-h-screen pt-100">
-      <Header />
       <SectionRenderer sections={pageData.sections} />
-      <Footer />
     </main>
   );
-} 
+}

--- a/kjt-portfolio/src/app/contact/page.tsx
+++ b/kjt-portfolio/src/app/contact/page.tsx
@@ -1,10 +1,7 @@
-import Footer from '@/components/Footer';
-
 export default function ContactPage() {
   return (
     <>
       <HeroPageTitle title="تماس با ما" />
-      <Footer />
     </>
   );
 }

--- a/kjt-portfolio/src/app/not-found.tsx
+++ b/kjt-portfolio/src/app/not-found.tsx
@@ -1,10 +1,8 @@
 import Link from 'next/link';
-import Header from '@/components/Header';
 
 export default function NotFound() {
   return (
     <main className="min-h-screen">
-      <Header />
       <div className="flex items-center justify-center min-h-[60vh]">
         <div className="text-center">
           <h1 className="text-6xl md:text-8xl font-bold text-primary-600 mb-4">۴۰۴</h1>

--- a/kjt-portfolio/src/app/products/page.tsx
+++ b/kjt-portfolio/src/app/products/page.tsx
@@ -1,10 +1,7 @@
-import Footer from '@/components/Footer';
-
 export default function ProductsPage() {
   return (
     <>
       <HeroPageTitle title="محصولات" />
-      <Footer />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- remove extra Header/Footer from individual pages
- skip homepage in dynamic routes

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870cd19bb3c8327ad336df3ecca373c